### PR TITLE
Data persistence

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,8 +47,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
       with:
-        tag_name: v0.0.96
-        release_name: Release v0.0.96
+        tag_name: v1.0.0-rc1
+        release_name: Release v1.0.0-rc1
         body: |
           another test
         draft: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /scratch
 /beautifulsoup4-4.12.3
 /test-files
+/2024-2025_EMC_HTML_UTM_links.csv

--- a/link_editor.py
+++ b/link_editor.py
@@ -2,6 +2,7 @@
 # Licensed with the GNU General Public License version 3 I guess
 
 #importing libraries
+import os
 import re
 import tkinter as tk
 import csv
@@ -63,11 +64,17 @@ def main():
             save_file.write(old_html_head + final_body_html + old_html_foot)
 
     #write the UTM parameters and links to a CSV file
-    with open('2024-2025_EMC_HTML_UTM_links.csv', 'w', newline='') as file:
-        writer = csv.writer(file)
-        writer.writerow(["Unit", "Campaign", "URL", "Source", "Medium", "Content", "UTM Link"])
-        for i in range(len(final_replace_links)):
-            writer.writerow([utm_unit, utm_campaign, final_replace_links[i], utm_source, 'email', final_utm_content_list[i], final_utm_links[i]])
+    if os.path.isfile("./2024-2025_EMC_HTML_UTM_links.csv") == True:
+        with open('2024-2025_EMC_HTML_UTM_links.csv', 'a', newline='') as file:
+            writer = csv.writer(file)
+            for i in range(len(final_replace_links)):
+                writer.writerow([utm_unit, utm_campaign, final_replace_links[i], utm_source, 'email', final_utm_content_list[i], final_utm_links[i]])
+    else:
+        with open('2024-2025_EMC_HTML_UTM_links.csv', 'w', newline='') as file:
+            writer = csv.writer(file)
+            writer.writerow(["Unit", "Campaign", "URL", "Source", "Medium", "Content", "UTM Link"])
+            for i in range(len(final_replace_links)):
+                writer.writerow([utm_unit, utm_campaign, final_replace_links[i], utm_source, 'email', final_utm_content_list[i], final_utm_links[i]])
     
     working_utm_links = []
     working_replace_links = []

--- a/link_editor.py
+++ b/link_editor.py
@@ -4,12 +4,13 @@
 #importing libraries
 import re
 import tkinter as tk
+import csv
 from tkinter import filedialog
 from bs4 import BeautifulSoup
 from functions import *
 
 # read the HTML source file
-def process_html():
+def main():
     file_path = filedialog.askopenfilename(filetypes=[("HTML files", "*.html")])
     if not file_path:
         return
@@ -35,7 +36,10 @@ def process_html():
         # hopefully I'll be able to get rid of this function at some point
         working_replace_links = quote_stripper(re.findall(r'(https?://\S+)', str(working_html)))
 
+        #puts both of these lists into variables to make them more easily accessible to other functions
         final_replace_links = link_filter(working_replace_links)
+
+        final_utm_content_list = content_grabber(working_html)
 
         working_utm_links = []
 
@@ -47,7 +51,7 @@ def process_html():
                 working_utm_links.append((url + "?utm_campaign=" + utm_unit + "-2024-2025-" + utm_campaign + "&utm_source=" + utm_source + "&utm_medium=email"))
 
         # create the final list of links with UTMs attached that will be added into the current working HTML string
-        final_utm_links = anchor_ripper(utm_content_appender(working_utm_links, content_grabber(working_html)))
+        final_utm_links = anchor_ripper(utm_content_appender(working_utm_links, final_utm_content_list))
         
         # looks through the working HTML string and replaces the links inside with their corresponding UTM links
         final_body_html = HTML_link_replacer(working_html, final_replace_links, final_utm_links)
@@ -57,6 +61,13 @@ def process_html():
     if save_path:
         with open(save_path, 'w') as save_file:
             save_file.write(old_html_head + final_body_html + old_html_foot)
+
+    #write the UTM parameters and links to a CSV file
+    with open('2024-2025_EMC_HTML_UTM_links.csv', 'w', newline='') as file:
+        writer = csv.writer(file)
+        writer.writerow(["Unit", "Campaign", "URL", "Source", "Medium", "Content", "UTM Link"])
+        for i in range(len(final_replace_links)):
+            writer.writerow([utm_unit, utm_campaign, final_replace_links[i], utm_source, 'email', final_utm_content_list[i], final_utm_links[i]])
     
     working_utm_links = []
     working_replace_links = []
@@ -95,7 +106,7 @@ utm_source_entry = tk.Entry(root)
 utm_source_entry.pack()
 
 # Create a button to select the HTML file
-select_button = tk.Button(root, text="Select HTML File", command=process_html)
+select_button = tk.Button(root, text="Select HTML File", command=main)
 select_button.pack()
 
 # Display a message to guide the user


### PR DESCRIPTION
Release candidate 1! This pull adds functionality for storing the UTM parameters and finished links in a CSV file that closely resembles the Excel spreadsheet that we've used to create UTM links to this point. This might mean that for the time being we'll be maintaining both spreadsheets, but that was always a possibility with having to update Marketing Cloud emails as well as HTML emails. Hopefully in the future I will be able to update the Excel spreadsheet directly, but at least there is documentation of what UTMs are being created for the time being.